### PR TITLE
Change deprecated 'fatcow' icons link to working link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1208,7 +1208,7 @@ This is a catch-all category for things that don't fit anywhere else.
 [402]: https://github.com/CedricGuillemet/ImGuizmo
 [403]: https://opensource.org/licenses/MIT
 [405]: https://github.com/FortAwesome/Font-Awesome/
-[406]: http://www.fatcow.com/free-icons
+[406]: https://github.com/gammasoft/fatcow
 [411]: https://github.com/nicodinh/kenney-icon-font/
 [412]: https://github.com/juliettef/IconFontCppHeaders
 [413]: https://gamesounds.xyz/


### PR DESCRIPTION
Changed old broken link to working link.

The new link goes to a github repo that hosts the same icon images as the previous link did under the same license, CC Attribution 3.0.

There are alternative links like:
  -  [iconarchive](https://www.iconarchive.com/show/farm-fresh-icons-by-fatcow.html) under the CC Attribution 4.0 
  - [iconfinder](https://www.iconfinder.com/iconsets/fatcow) under CC Attribution 3.0
  
However this pull request only changed the main link to the github repo link that contains the icons, since I do not know if the Peers community would like to have more than one single link added to single resource.