### PR TITLE
GPU Performance and Debugging Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1104,7 +1104,7 @@ This is a catch-all category for things that don't fit anywhere else.
 [287]: https://www.jamendo.com/
 [288]: https://openclipart.org/
 [289]: https://creativecommons.org/publicdomain/zero/1.0/
-[290]: https://github.com/grumdrig/jsfxr
+[290]: https://github.com/chr15m/jsfxr
 [291]: https://github.com/google/material-design-icons
 [292]: http://castle-engine.sourceforge.net/
 [293]: https://github.com/gamekit-developers/gamekit

--- a/README.md
+++ b/README.md
@@ -421,6 +421,7 @@ may be removed upon clarification.
 * [PuzzleGame][257] - A slider puzzle game. Uses Android port of Cocos2D
   engine. [Expat][11] (code and assets).
 * [Terasology][230] - A 3D voxel world game. [Apache2.0][20] (code and assets).
+* [Unciv][442] - Open source, moddability-focused Android and Desktop remake of Civ V. [MPLv2][166].
 
 ### Other/Multiple ###
 
@@ -1243,3 +1244,4 @@ This is a catch-all category for things that don't fit anywhere else.
 [439]: https://github.com/Anuken/Mindustry
 [440]: https://github.com/friflo/Friflo.Json.Fliox/blob/main/Engine/README.md
 [441]: https://github.com/VBproDev/Canvascript
+[442]: https://github.com/yairm210/Unciv

--- a/README.md
+++ b/README.md
@@ -578,6 +578,13 @@ This category contains any 'grab-bags' of different kinds of art assets.
 * [Sproxel][28] - A 3D interface for quickly editing and creating voxel-based 3D
   models. [3-clause BSD][29].
 
+
+### GPU Performance and Debugging ###
+
+* [Render Doc][443] - Graphics debugger that allows quick and easy single-frame capture and detailed introspection of any application using Vulkan, D3D11, OpenGL & OpenGL ES or D3D12 across Windows, Linux, Android, or Nintendo Switch™. [MIT][403].
+* [NVTOP][444] - GPU & Accelerator process monitoring for AMD, Apple, Huawei, Intel, NVIDIA and Qualcomm. [GNU GPLv3][23].
+* [RadeonTop][445] - View your GPU utilization, both for the total activity percent and individual blocks. [GNU GPLv3][23].
+
 ## Learning Resources ##
 
 These are all collections of information to help you learn about things that
@@ -1245,3 +1252,6 @@ This is a catch-all category for things that don't fit anywhere else.
 [440]: https://github.com/friflo/Friflo.Json.Fliox/blob/main/Engine/README.md
 [441]: https://github.com/VBproDev/Canvascript
 [442]: https://github.com/yairm210/Unciv
+[443]: https://renderdoc.org/
+[444]: https://github.com/Syllo/nvtop
+[445]: https://github.com/clbr/radeontop

--- a/README.md
+++ b/README.md
@@ -581,7 +581,7 @@ This category contains any 'grab-bags' of different kinds of art assets.
 
 ### GPU Performance and Debugging ###
 
-* [Render Doc][443] - Graphics debugger that allows quick and easy single-frame capture and detailed introspection of any application using Vulkan, D3D11, OpenGL & OpenGL ES or D3D12 across Windows, Linux, Android, or Nintendo Switch™. [MIT][403].
+* [RenderDoc][443] - Graphics debugger that allows quick and easy single-frame capture and detailed introspection of any application using Vulkan, D3D11, OpenGL & OpenGL ES or D3D12 across Windows, Linux, Android, or Nintendo Switch™. [MIT][403].
 * [NVTOP][444] - GPU & Accelerator process monitoring for AMD, Apple, Huawei, Intel, NVIDIA and Qualcomm. [GNU GPLv3][23].
 * [RadeonTop][445] - View your GPU utilization, both for the total activity percent and individual blocks. [GNU GPLv3][23].
 


### PR DESCRIPTION
Added new section for GPU utilization / performance measurement and frame capture API debugging. Feel free to re-categorize.

-RenderDoc allows frame capture for debugging graphics API. An open alternative to NVIDIA Nsight, and Radeon Developer Tool Suite (formally PerfStudio). Great for API level debugging.

-NVTOP graphs GPU utilization over time. Works on AMD + NVIDIA. Linux only.

-RadeonTop graphs render pipeline utilization. Works on AMD + NVIDIA. Linux only.