### PR TITLE
Add Meccha Chameleon Art fan atlas

### DIFF
--- a/README.md
+++ b/README.md
@@ -1283,3 +1283,8 @@ This is a catch-all category for things that don't fit anywhere else.
 [454]: https://github.com/YuriSizov/glasan-fx
 [455]: https://github.com/fernandotonon/QtMeshEditor
 [456]: https://github.com/ArtyProf/steamworks-ffi-node
+
+## Community Resource Additions
+
+<!-- Added 2026-06-24 by zlc000190 -->
+- [Meccha Chameleon Art](https://mecchachameleon.art/) — Fan-made browser companion for Meccha Chameleon (paint-based hide-and-seek Steam game). 50+ hiding spot atlas with color analysis, bilingual (EN/中文). GitHub awesome list: https://github.com/zlc000190/AwesomeMecchaChameleonHideSpot


### PR DESCRIPTION
## Community Resource

- [Meccha Chameleon Art](https://mecchachameleon.art/) — Fan-made browser companion for Meccha Chameleon, a paint-based hide-and-seek Steam game. 50+ hiding spot atlas with color analysis, bilingual (EN/中文).
- GitHub: https://github.com/zlc000190/AwesomeMecchaChameleonHideSpot

Fan-made, unofficial. Meccha Chameleon is © LEMORION.