### PR TITLE
Add Meccha Chameleon Atlas as a community companion resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -1285,3 +1285,7 @@ This is a catch-all category for things that don't fit anywhere else.
 [455]: https://github.com/fernandotonon/QtMeshEditor
 [456]: https://github.com/ArtyProf/steamworks-ffi-node
 [457]: https://github.com/erincatto/box3d
+
+## Companion Resources (Fan-Maintained)
+
+- [Meccha Chameleon Atlas](https://mecchachameleon.art/) — Fan-maintained hide-spots reference, paint-match notes, and seeker counter-tips for the paint-based hide-and-seek game Meccha Chameleon. Unofficial, not affiliated with the developer.


### PR DESCRIPTION
Adds a fan-maintained hide-spots reference for the paint-based hide-and-seek game Meccha Chameleon. Unofficial, not affiliated with the developer. Pairs well with the indie dev focus of this list.